### PR TITLE
Add support for "Others" moon option

### DIFF
--- a/LethalExpansion/LethalExpansion.cs
+++ b/LethalExpansion/LethalExpansion.cs
@@ -387,7 +387,7 @@ public class LethalExpansion : BaseUnityPlugin
         }
         else if (runtimeDungeon.Generator.DungeonFlow == null)
         {
-            runtimeDungeon.Generator.DungeonFlow = RoundManager.Instance.dungeonFlowTypes[0];
+            runtimeDungeon.Generator.DungeonFlow = RoundManager.Instance.dungeonFlowTypes[0].dungeonFlow;
 
             LethalExpansion.Log.LogInfo("Setting missing DungeonFlow in DungeonGenerator");
         }
@@ -483,7 +483,7 @@ public class LethalExpansion : BaseUnityPlugin
         dungeonGenerator.transform.position = new Vector3(0, -200, 0);
 
         RuntimeDungeon runtimeDungeon = dungeonGenerator.AddComponent<RuntimeDungeon>();
-        runtimeDungeon.Generator.DungeonFlow = RoundManager.Instance.dungeonFlowTypes[0];
+        runtimeDungeon.Generator.DungeonFlow = RoundManager.Instance.dungeonFlowTypes[0].dungeonFlow;
         runtimeDungeon.Generator.LengthMultiplier = 0.8f;
         runtimeDungeon.Generator.PauseBetweenRooms = 0.2f;
         runtimeDungeon.GenerateOnStart = false;

--- a/LethalExpansion/LethalExpansion.cs
+++ b/LethalExpansion/LethalExpansion.cs
@@ -24,9 +24,9 @@ namespace LethalExpansionCore;
 
 public static class PluginInformation
 {
-    public const string PLUGIN_GUID = "com.github.lethalmods.lethalexpansioncore";
-    public const string PLUGIN_NAME = "LethalExpansion(core)";
-    public const string PLUGIN_VERSION = "1.3.15";
+    public const string PLUGIN_GUID = "com.github.lethalmods.lethalexpansioncorepatch";
+    public const string PLUGIN_NAME = "LethalExpansion(core) - Patched";
+    public const string PLUGIN_VERSION = "1.3.18";
 }
 
 [BepInPlugin(PluginInformation.PLUGIN_GUID, PluginInformation.PLUGIN_NAME, PluginInformation.PLUGIN_VERSION)]

--- a/LethalExpansion/Patches/MenuManager_Patch.cs
+++ b/LethalExpansion/Patches/MenuManager_Patch.cs
@@ -14,7 +14,7 @@ internal class MenuManager_Patch
             if (__instance.versionNumberText != null)
             {
                 __instance.versionNumberText.enableWordWrapping = false;
-                __instance.versionNumberText.text += $"     LE(core)v{LethalExpansion.ModVersion}";
+                __instance.versionNumberText.text += $"     LE(core)patch v{LethalExpansion.ModVersion}";
             }
         }
     }

--- a/LethalExpansion/Patches/Terminal_Patch.cs
+++ b/LethalExpansion/Patches/Terminal_Patch.cs
@@ -247,8 +247,10 @@ internal class Terminal_Patch
                     return otherChance.SpawnWeight;
 
                 }
-                LethalExpansion.Log.LogError($"No spawn rate for '{scrap.itemName}' on '{level.PlanetName}', using global spawn weight of {scrap.globalSpawnWeight}.");
-                return scrap.globalSpawnWeight;
+                //LethalExpansion.Log.LogError($"No spawn rate for '{scrap.itemName}' on '{level.PlanetName}', using global spawn weight of {scrap.globalSpawnWeight}.");
+                //return scrap.globalSpawnWeight;
+                LethalExpansion.Log.LogWarning($"No spawn rate for '{scrap.itemName}' on '{level.PlanetName}', scrap will not spawn.");
+                return null;
             }
 
             ScrapSpawnChancePerScene scrapSpawnChance = perPlanetSpawnWeight.First(l => l.SceneName == level.PlanetName);

--- a/LethalExpansion/Patches/Terminal_Patch.cs
+++ b/LethalExpansion/Patches/Terminal_Patch.cs
@@ -231,6 +231,7 @@ internal class Terminal_Patch
         {
             if (scrap.useGlobalSpawnWeight)
             {
+                LethalExpansion.Log.LogDebug($"Using global spawn rate for '{scrap.itemName}' on '{level.PlanetName}': '{scrap.globalSpawnWeight}'.");
                 return scrap.globalSpawnWeight;
             }
 
@@ -239,10 +240,19 @@ internal class Terminal_Patch
             bool containsPlanet = perPlanetSpawnWeight.Any(l => l.SceneName == level.PlanetName);
             if (!containsPlanet)
             {
+                if( perPlanetSpawnWeight.Any(l => l.SceneName == "Others") )
+                {
+                    ScrapSpawnChancePerScene otherChance = perPlanetSpawnWeight.First(l => l.SceneName == "Others");
+                    LethalExpansion.Log.LogDebug($"Spawn rate for '{scrap.itemName}' on '{level.PlanetName}': '{otherChance.SpawnWeight}' (Others).");
+                    return otherChance.SpawnWeight;
+
+                }
+                LethalExpansion.Log.LogError($"No spawn rate for '{scrap.itemName}' on '{level.PlanetName}'.");
                 return null;
             }
 
             ScrapSpawnChancePerScene scrapSpawnChance = perPlanetSpawnWeight.First(l => l.SceneName == level.PlanetName);
+            LethalExpansion.Log.LogDebug($"Spawn rate for '{scrap.itemName}' on '{level.PlanetName}': '{scrapSpawnChance.SpawnWeight}'.");
             return scrapSpawnChance.SpawnWeight;
         }
 

--- a/LethalExpansion/Patches/Terminal_Patch.cs
+++ b/LethalExpansion/Patches/Terminal_Patch.cs
@@ -231,7 +231,7 @@ internal class Terminal_Patch
         {
             if (scrap.useGlobalSpawnWeight)
             {
-                LethalExpansion.Log.LogDebug($"Using global spawn rate for '{scrap.itemName}' on '{level.PlanetName}': '{scrap.globalSpawnWeight}'.");
+                LethalExpansion.Log.LogDebug($"Using global spawn rate for '{scrap.itemName}' on '{level.PlanetName}': {scrap.globalSpawnWeight}.");
                 return scrap.globalSpawnWeight;
             }
 
@@ -243,16 +243,16 @@ internal class Terminal_Patch
                 if( perPlanetSpawnWeight.Any(l => l.SceneName == "Others") )
                 {
                     ScrapSpawnChancePerScene otherChance = perPlanetSpawnWeight.First(l => l.SceneName == "Others");
-                    LethalExpansion.Log.LogDebug($"Spawn rate for '{scrap.itemName}' on '{level.PlanetName}': '{otherChance.SpawnWeight}' (Others).");
+                    LethalExpansion.Log.LogDebug($"Spawn rate for '{scrap.itemName}' on '{level.PlanetName}': {otherChance.SpawnWeight} (Others).");
                     return otherChance.SpawnWeight;
 
                 }
-                LethalExpansion.Log.LogError($"No spawn rate for '{scrap.itemName}' on '{level.PlanetName}'.");
-                return null;
+                LethalExpansion.Log.LogError($"No spawn rate for '{scrap.itemName}' on '{level.PlanetName}', using global spawn weight of {scrap.globalSpawnWeight}.");
+                return scrap.globalSpawnWeight;
             }
 
             ScrapSpawnChancePerScene scrapSpawnChance = perPlanetSpawnWeight.First(l => l.SceneName == level.PlanetName);
-            LethalExpansion.Log.LogDebug($"Spawn rate for '{scrap.itemName}' on '{level.PlanetName}': '{scrapSpawnChance.SpawnWeight}'.");
+            LethalExpansion.Log.LogDebug($"Spawn rate for '{scrap.itemName}' on '{level.PlanetName}': {scrapSpawnChance.SpawnWeight}.");
             return scrapSpawnChance.SpawnWeight;
         }
 


### PR DESCRIPTION
LECore doesn't support the "Others" moon option, which makes some scrap not spawn on v50 moons. Also fixes compile error against v50.